### PR TITLE
Fix autojoin

### DIFF
--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -13,7 +13,7 @@ module ApplicationCable
         if current_user = env['warden'].user
           current_user
         else
-          reject_authorized_connection
+          reject_unauthorized_connection
         end
       end
   end

--- a/app/controllers/chatrooms_controller.rb
+++ b/app/controllers/chatrooms_controller.rb
@@ -29,7 +29,9 @@ class ChatroomsController < ApplicationController
     @chatroom = Chatroom.new(chatroom_params)
 
     respond_to do |format|
+
       if @chatroom.save
+        @chatroom.chatroom_users.where(user_id: current_user.id).first_or_create
         format.html { redirect_to @chatroom, notice: 'Chatroom was successfully created.' }
         format.json { render :show, status: :created, location: @chatroom }
       else


### PR DESCRIPTION
This fixes the behavioral case of when a user creates a chatroom, and it auto-joins without creating the `chatroom_user` record.
