### PR TITLE
Unread messages fix

### DIFF
--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -13,7 +13,7 @@ module ApplicationCable
         if current_user = env['warden'].user
           current_user
         else
-          reject_authorized_connection
+          reject_unauthorized_connection
         end
       end
   end

--- a/app/controllers/chatroom_users_controller.rb
+++ b/app/controllers/chatroom_users_controller.rb
@@ -4,6 +4,7 @@ class ChatroomUsersController < ApplicationController
 
   def create
     @chatroom_user = @chatroom.chatroom_users.where(user_id: current_user.id).first_or_create
+    @chatroom_user.update(last_read_at: Time.zone.now)
     redirect_to @chatroom
   end
 

--- a/app/controllers/chatrooms_controller.rb
+++ b/app/controllers/chatrooms_controller.rb
@@ -29,7 +29,9 @@ class ChatroomsController < ApplicationController
     @chatroom = Chatroom.new(chatroom_params)
 
     respond_to do |format|
+
       if @chatroom.save
+        @chatroom.chatroom_users.where(user_id: current_user.id).first_or_create
         format.html { redirect_to @chatroom, notice: 'Chatroom was successfully created.' }
         format.json { render :show, status: :created, location: @chatroom }
       else

--- a/app/views/chatrooms/show.html.erb
+++ b/app/views/chatrooms/show.html.erb
@@ -6,7 +6,7 @@
 <% unread_messages = false %>
 <div data-behavior='messages' data-chatroom-id='<%= @chatroom.id %>'>
   <% @messages.each do |message| %>
-    <% if !unread_messages && @chatroom_user.last_read_at < message.created_at %>
+    <% if !unread_messages && @chatroom_user.last_read_at.present? && @chatroom_user.last_read_at < message.created_at %>
       <% unread_messages = true %>
       <div class="strike"><span>Unread Messages</span></div>
     <% end %>

--- a/app/views/chatrooms/show.html.erb
+++ b/app/views/chatrooms/show.html.erb
@@ -6,7 +6,7 @@
 <% unread_messages = false %>
 <div data-behavior='messages' data-chatroom-id='<%= @chatroom.id %>'>
   <% @messages.each do |message| %>
-    <% if !unread_messages && @chatroom_user.last_read_at.present? && @chatroom_user.last_read_at < message.created_at %>
+    <% if !unread_messages && @chatroom_user.last_read_at < message.created_at %>
       <% unread_messages = true %>
       <div class="strike"><span>Unread Messages</span></div>
     <% end %>


### PR DESCRIPTION
This should fix #2 where we were evaluating NIL in the view because it wasn't stamped by default.  So I used your idea to change the behavior so where a `chatroom_user` is found or created they are automatically updated by stamping with current time.  This does not introduce any breaking changes.
